### PR TITLE
chore: bump package to 1.0.4 with dependency and Android updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+- **Google Play Billing Library**
+  - Google Play Billing Library v8.0 deprecated `SubscriptionUpdateParams.setReplaceProrationMode()` and replaced it with `SubscriptionUpdateParams.setReplacementMode()`. Accordingly, the enum has changed from `ProrationMode` to `ReplacementMode`.
+
 ## 1.0.3
 - Deprecation cleanup: Eliminated legacy implementations tied to Android Billing Client v8.
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ For help on editing plugin code, view the [documentation](https://flutter.io/dev
 | appStoreSync            |          |       | This iOS Specific method to sync with AppStore, After successfully calling this method, call `getAvailablePurchases` for get active purchases.
 | showInAppMessageAndroid      |                                                                                                                                                                                |                       | Google Play will show users messaging during grace period and account hold once per day and provide them an opportunity to fix their payment without leaving the app                                                                                                                                                                                                                                                                                                                                                                                                                                          |
 
+## 📌 Android Proration Mode Migration (Billing Library 8.0+)
+  Google Play Billing Library v8.0 deprecated `SubscriptionUpdateParams.setReplaceProrationMode()` and replaced it with `SubscriptionUpdateParams.setReplacementMode()`.
+Accordingly, the enum has changed from `ProrationMode` to `ReplacementMode`.
+#### Migration mapping:
+  | Old (ProrationMode) | New (ReplacementMode) |
+  | :----: | :------: |
+  | UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY | UNKNOWN_REPLACEMENT_MODE |
+  | IMMEDIATE_WITH_TIME_PRORATION | WITH_TIME_PRORATION |
+  | IMMEDIATE_AND_CHARGE_PRORATED_PRICE | CHARGE_PRORATED_PRICE |
+  | IMMEDIATE_WITHOUT_PRORATION | WITHOUT_PRORATION |
+  | IMMEDIATE_AND_CHARGE_FULL_PRICE | CHARGE_FULL_PRICE |
+  | DEFERRED | DEFERRED |
+
 ## 🛒 Purchase flow in `flutter_inapp_purchase_plus`
 
 > When you've successfully received result from `purchaseUpdated` listener, you'll have to `verify` the purchase either by `acknowledgePurchaseAndroid`, `consumePurchaseAndroid`, `finishTransactionIOS` depending on the purchase types or platforms. You'll have to use `consumePurchaseAndroid` for `consumable` products and `android` and `acknowledgePurchaseAndroid` for `non-consumable` products either `subscription`. For `ios`, there is no differences in `verifying` purchases. You can just call `finishTransaction`. If you do not verify the purchase, it will be refunded within 3 days to users. Lastly, if you want to abstract three different methods into one, consider using `finishTransaction` method.
@@ -258,7 +271,7 @@ This method is used to synchronize the app with the App Store and restore any pr
 
 ```dart
   void retsorePurchase() async {
-    final result = await FlutterInappPurchase.instance.restorePurchases();
+    final result = await FlutterInappPurchase.instance.appStoreSync();
     if (result) {
       final purchases = await FlutterInappPurchase.instance.getAvailablePurchases();
       // This purchase is list of PurchasedItem

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,17 @@ group 'com.noble.flutterinapppurchaseplus'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.10'
+    ext.kotlin_version = '2.1.0'
+    ext {
+        agp_version = '8.13.0'
+    }
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath "com.android.tools.build:gradle:$agp_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -28,10 +31,10 @@ android {
     if (project.android.hasProperty('namespace')) {
         namespace 'com.noble.flutterinapppurchaseplus'
     }
-    compileSdkVersion 33
+    compileSdkVersion 36
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 26
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     sourceSets {
@@ -41,12 +44,12 @@ android {
         disable 'InvalidPackage'
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
+#Mon Sep 15 10:54:24 IST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
-networkTimeout=10000
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -9,23 +9,23 @@ plugins {
 
 android {
     namespace = "com.noble.flutterinapppurchaseplusexample"
-    compileSdk = 35
-    ndkVersion = flutter.ndkVersion
+    compileSdk = 36
+    ndkVersion = '29.0.14033849 rc4'
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_18
-        targetCompatibility = JavaVersion.VERSION_18
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "${JavaVersion.VERSION_18}"
+        jvmTarget = JavaVersion.VERSION_17
     }
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.noble.flutterinapppurchaseplusexample"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
     }
@@ -45,6 +45,6 @@ flutter {
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test:runner:1.6.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test:runner:1.7.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Apr 14 16:24:48 IST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -15,9 +15,9 @@ pluginManagement {
 }
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.9.1' apply false
+    id "com.android.application" version '8.13.0' apply false
     // END: FlutterFire Configuration
-    id "org.jetbrains.kotlin.android" version "1.9.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 include ":app"
  

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>12.0</string>
+  <string>13.0</string>
 </dict>
 </plist>

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -708,26 +708,36 @@ class FlutterInappPurchase {
 /// A list of valid values for ProrationMode parameter
 /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode
 class AndroidProrationMode {
-  /// Replacement takes effect immediately, and the user is charged full price of new plan and is given a full billing cycle of subscription, plus remaining prorated time from the old plan.
-  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode#IMMEDIATE_AND_CHARGE_FULL_PRICE
-  static const int IMMEDIATE_AND_CHARGE_FULL_PRICE = 5;
 
-  /// Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
-  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode#DEFERRED
-  static const int DEFERRED = 4;
+/// Updated replacement mode key
+/// UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY => UNKNOWN_REPLACEMENT_MODE
+/// IMMEDIATE_WITH_TIME_PRORATION => WITH_TIME_PRORATION
+/// IMMEDIATE_AND_CHARGE_PRORATED_PRICE => CHARGE_PRORATED_PRICE
+/// IMMEDIATE_WITHOUT_PRORATION => WITHOUT_PRORATION
+/// IMMEDIATE_AND_CHARGE_FULL_PRICE => CHARGE_FULL_PRICE
+/// DEFERRED => DEFERRED
 
-  /// Replacement takes effect immediately, and the billing cycle remains the same. The price for the remaining period will be charged. This option is only available for subscription upgrade.
-  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode#immediate_and_charge_prorated_price
-  static const int IMMEDIATE_AND_CHARGE_PRORATED_PRICE = 2;
+/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#UNKNOWN_REPLACEMENT_MODE()
+static const int UNKNOWN_REPLACEMENT_MODE = 0;
 
-  /// Replacement takes effect immediately, and the new price will be charged on next recurrence time. The billing cycle stays the same.
-  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode#immediate_without_proration
-  static const int IMMEDIATE_WITHOUT_PRORATION = 3;
+/// Replacement takes effect immediately, and the remaining time will be prorated and credited to the user. This is the current default behavior.
+/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#WITH_TIME_PRORATION()
+ static const int WITH_TIME_PRORATION = 1;
 
-  /// Replacement takes effect immediately, and the remaining time will be prorated and credited to the user. This is the current default behavior.
-  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode#immediate_with_time_proration
-  static const int IMMEDIATE_WITH_TIME_PRORATION = 1;
+/// Replacement takes effect immediately, and the billing cycle remains the same. The price for the remaining period will be charged. This option is only available for subscription upgrade.
+/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#CHARGE_PRORATED_PRICE()
+ static const int CHARGE_PRORATED_PRICE = 2;
 
-  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode#unknown_subscription_upgrade_downgrade_policy
-  static const int UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY = 0;
+/// Replacement takes effect immediately, and the new price will be charged on next recurrence time. The billing cycle stays the same.
+/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#WITHOUT_PRORATION()
+ static const int WITHOUT_PRORATION = 3;
+
+/// Replacement takes effect immediately, and the user is charged full price of new plan and is given a full billing cycle of subscription, plus remaining prorated time from the old plan.
+/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#CHARGE_FULL_PRICE()
+ static const int CHARGE_FULL_PRICE = 5;
+
+/// Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
+/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#DEFERRED()
+ static const int DEFERRED = 6;
+ 
 }

--- a/lib/flutter_inapp_purchase.dart
+++ b/lib/flutter_inapp_purchase.dart
@@ -708,36 +708,34 @@ class FlutterInappPurchase {
 /// A list of valid values for ProrationMode parameter
 /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode
 class AndroidProrationMode {
+  /// Updated replacement mode key
+  /// UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY => UNKNOWN_REPLACEMENT_MODE
+  /// IMMEDIATE_WITH_TIME_PRORATION => WITH_TIME_PRORATION
+  /// IMMEDIATE_AND_CHARGE_PRORATED_PRICE => CHARGE_PRORATED_PRICE
+  /// IMMEDIATE_WITHOUT_PRORATION => WITHOUT_PRORATION
+  /// IMMEDIATE_AND_CHARGE_FULL_PRICE => CHARGE_FULL_PRICE
+  /// DEFERRED => DEFERRED
 
-/// Updated replacement mode key
-/// UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY => UNKNOWN_REPLACEMENT_MODE
-/// IMMEDIATE_WITH_TIME_PRORATION => WITH_TIME_PRORATION
-/// IMMEDIATE_AND_CHARGE_PRORATED_PRICE => CHARGE_PRORATED_PRICE
-/// IMMEDIATE_WITHOUT_PRORATION => WITHOUT_PRORATION
-/// IMMEDIATE_AND_CHARGE_FULL_PRICE => CHARGE_FULL_PRICE
-/// DEFERRED => DEFERRED
+  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#UNKNOWN_REPLACEMENT_MODE()
+  static const int UNKNOWN_REPLACEMENT_MODE = 0;
 
-/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#UNKNOWN_REPLACEMENT_MODE()
-static const int UNKNOWN_REPLACEMENT_MODE = 0;
+  /// Replacement takes effect immediately, and the remaining time will be prorated and credited to the user. This is the current default behavior.
+  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#WITH_TIME_PRORATION()
+  static const int WITH_TIME_PRORATION = 1;
 
-/// Replacement takes effect immediately, and the remaining time will be prorated and credited to the user. This is the current default behavior.
-/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#WITH_TIME_PRORATION()
- static const int WITH_TIME_PRORATION = 1;
+  /// Replacement takes effect immediately, and the billing cycle remains the same. The price for the remaining period will be charged. This option is only available for subscription upgrade.
+  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#CHARGE_PRORATED_PRICE()
+  static const int CHARGE_PRORATED_PRICE = 2;
 
-/// Replacement takes effect immediately, and the billing cycle remains the same. The price for the remaining period will be charged. This option is only available for subscription upgrade.
-/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#CHARGE_PRORATED_PRICE()
- static const int CHARGE_PRORATED_PRICE = 2;
+  /// Replacement takes effect immediately, and the new price will be charged on next recurrence time. The billing cycle stays the same.
+  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#WITHOUT_PRORATION()
+  static const int WITHOUT_PRORATION = 3;
 
-/// Replacement takes effect immediately, and the new price will be charged on next recurrence time. The billing cycle stays the same.
-/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#WITHOUT_PRORATION()
- static const int WITHOUT_PRORATION = 3;
+  /// Replacement takes effect immediately, and the user is charged full price of new plan and is given a full billing cycle of subscription, plus remaining prorated time from the old plan.
+  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#CHARGE_FULL_PRICE()
+  static const int CHARGE_FULL_PRICE = 5;
 
-/// Replacement takes effect immediately, and the user is charged full price of new plan and is given a full billing cycle of subscription, plus remaining prorated time from the old plan.
-/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#CHARGE_FULL_PRICE()
- static const int CHARGE_FULL_PRICE = 5;
-
-/// Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
-/// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#DEFERRED()
- static const int DEFERRED = 6;
- 
+  /// Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
+  /// https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.SubscriptionUpdateParams.ReplacementMode#DEFERRED()
+  static const int DEFERRED = 6;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ name: flutter_inapp_purchase_plus
 description: In App Purchase plugin for flutter. This project has been forked by
   flutter_inapp_purchase and we are willing to share same experience with that on
   flutter_inapp_purchase.
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/IMHitesh/flutter_inapp_purchase_plus/blob/main/pubspec.yaml
 environment:
   sdk: ">=2.15.0 <4.0.0"
@@ -18,9 +18,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  http: ^1.1.0
+  http: ^1.5.0
   meta: ^1.9.1
-  platform: ^3.1.3
+  platform: ^3.1.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Updated dependencies (`http`, `platform`)
- Migrated Android proration mode to new ReplacementMode API (Billing v8)
- Updated Android build config (Kotlin, AGP, JVM target, NDK)